### PR TITLE
Console Escape Stripping

### DIFF
--- a/Source/SwiftyTextTable/TextTable.swift
+++ b/Source/SwiftyTextTable/TextTable.swift
@@ -10,6 +10,8 @@ import Foundation
 
 // MARK: Console Escape Stripping
 private let strippingPattern = "(?:\u{001B}\\[(?:[0-9]|;)+m)*(.*?)(?:\u{001B}\\[0m)+"
+
+// We can safely force try this regex because the pattern has be tested to work.
 // swiftlint:disable:next force_try
 private let strippingRegex = try! NSRegularExpression(pattern: strippingPattern, options: [])
 

--- a/Source/SwiftyTextTableTests/SwiftyTextTableTests.swift
+++ b/Source/SwiftyTextTableTests/SwiftyTextTableTests.swift
@@ -50,9 +50,33 @@ class SwiftyTextTableTests: XCTestCase {
         XCTAssertEqual(output, expected)
     }
 
+    func testStripping() {
+        let c1 = TextTableColumn(header: "\u{001B}[0mHello\u{001B}[0m")
+        XCTAssertEqual(c1.width, 5)
+
+        let c2 = TextTableColumn(header: "\u{001B}[31m\u{001B}[4;31;93mHello World\u{001B}[0m\u{001B}[0m")
+        XCTAssertEqual(c2.width, 11)
+
+        let c3 = TextTableColumn(header: "\u{001B}[0m\u{001B}[0m")
+        XCTAssertEqual(c3.width, 0)
+
+        let c4 = TextTableColumn(header: "\u{001B}[31mHello World\u{001B}[0m")
+        XCTAssertEqual(c4.width, 11)
+
+        let c5 = TextTableColumn(header: "\u{001B}[4;31;42;93;5mHello World\u{001B}[0m")
+        XCTAssertEqual(c5.width, 11)
+
+        let c6 = TextTableColumn(header: "\u{001B}[4;31;93mHello World\u{001B}[0m")
+        XCTAssertEqual(c6.width, 11)
+
+        let c7 = TextTableColumn(header: "Hello World")
+        XCTAssertEqual(c7.width, 11)
+    }
+
     // MARK: - protocol XCTestCaseProvider for SPM
     lazy var allTests: [(String, () throws -> Void)] = [
         ("testRenderDefault", self.testRenderDefault),
-        ("testRenderCustom", self.testRenderCustom)
+        ("testRenderCustom", self.testRenderCustom),
+        ("testStripping", self.testRenderCustom)
     ]
 }


### PR DESCRIPTION
Closes #5 

This PR adds the capability to calculate string length by stripping the escape sequences that are inserted for console formatting (e.g. [Rainbow](https://github.com/onevcat/Rainbow)).
