### PR TITLE
Reduce build time of `TextTable.renderTableHeader()`

### DIFF
--- a/Source/SwiftyTextTable/TextTable.swift
+++ b/Source/SwiftyTextTable/TextTable.swift
@@ -140,8 +140,9 @@ public struct TextTable {
             return nil
         }
 
+        let calculateWidth: (Int, TextTableColumn) -> Int = { $0 + $1.width + 2 }
         let separator = cornerFence +
-            repeatElement(rowFence, count: columns.reduce(0, { $0 + $1.width + 2 }) + columns.count - 1).joined() +
+            repeatElement(rowFence, count: columns.reduce(0, calculateWidth) + columns.count - 1).joined() +
             cornerFence
         let title = fence(strings: [" \(header.withPadding(count: separator.characters.count - 4)) "], separator: columnFence)
 


### PR DESCRIPTION
On MacBook Pro (Retina, 13-inch, Late 2013) 2.6 GHz Intel Core i5,
cumulative time is reduced from 2186.8ms to 29.0ms. (by [Build Time Analyzer](https://github.com/RobertGummesson/BuildTimeAnalyzer-for-Xcode/))
<img width="1012" alt="screenshot 2016-12-02 19 49 34" src="https://cloud.githubusercontent.com/assets/33430/20832213/4f3731bc-b8cc-11e6-8a21-01db8a8994fe.png">
<img width="1016" alt="screenshot 2016-12-02 20 13 39" src="https://cloud.githubusercontent.com/assets/33430/20832214/5472be44-b8cc-11e6-8c02-33bac28f90c3.png">