### PR TITLE
Improved support for escape sequences

### DIFF
--- a/Source/SwiftyTextTable/TextTable.swift
+++ b/Source/SwiftyTextTable/TextTable.swift
@@ -208,11 +208,8 @@ public extension Array where Element: TextTableRepresentable {
 
 private extension String {
     func withPadding(count: Int) -> String {
-#if swift(>=3.2)
-        let length = self.count
-#else
-        let length = self.characters.count
-#endif
+        let length = self.strippedLength()
+
         if length < count {
             return self +
                 repeatElement(" ", count: count - length).joined()

--- a/Source/SwiftyTextTable/TextTable.swift
+++ b/Source/SwiftyTextTable/TextTable.swift
@@ -10,7 +10,7 @@ import Foundation
 
 typealias Regex = NSRegularExpression
 
-private let strippingPattern = "(?:\u{001B}\\[(?:[0-9]|;)+m)*(.*?)(?:\u{001B}\\[0m)+"
+private let strippingPattern = "\\\u{001B}\\[[0-1];[0-9][0-9]m"
 
 // We can safely force try this regex because the pattern has be tested to work.
 // swiftlint:disable:next force_try

--- a/Source/SwiftyTextTable/TextTable.swift
+++ b/Source/SwiftyTextTable/TextTable.swift
@@ -10,7 +10,7 @@ import Foundation
 
 typealias Regex = NSRegularExpression
 
-private let strippingPattern = "\\\u{001B}\\[[0-1];[0-9][0-9]m"
+private let strippingPattern = "\\\u{001B}\\[([0-9][0-9]?m|[0-9](;[0-9]*)*m)"
 
 // We can safely force try this regex because the pattern has be tested to work.
 // swiftlint:disable:next force_try
@@ -27,7 +27,7 @@ private extension String {
             in: self,
             options: [],
             range: NSRange(location: 0, length: length),
-            withTemplate: "$1"
+            withTemplate: ""
         )
     }
 }

--- a/Tests/SwiftyTextTableTests/SwiftyTextTableTests.swift
+++ b/Tests/SwiftyTextTableTests/SwiftyTextTableTests.swift
@@ -109,6 +109,12 @@ class SwiftyTextTableTests: XCTestCase {
 
             let c7 = TextTableColumn(header: "Hello World")
             XCTAssertEqual(c7.width(), 11)
+        
+            let c8 = TextTableColumn(header: "\u{001B}[0;31mHello World\u{001B}[0;30m")
+            XCTAssertEqual(c8.width(), 11)
+        
+            let c9 = TextTableColumn(header: "\u{001B}[1;31mHello World\u{001B}[0;30m")
+        XCTAssertEqual(c9.width(), 11)
         #endif
     }
 

--- a/Tests/SwiftyTextTableTests/SwiftyTextTableTests.swift
+++ b/Tests/SwiftyTextTableTests/SwiftyTextTableTests.swift
@@ -114,7 +114,7 @@ class SwiftyTextTableTests: XCTestCase {
             XCTAssertEqual(c8.width(), 11)
         
             let c9 = TextTableColumn(header: "\u{001B}[1;31mHello World\u{001B}[0;30m")
-        XCTAssertEqual(c9.width(), 11)
+            XCTAssertEqual(c9.width(), 11)
         #endif
     }
 


### PR DESCRIPTION
This should resolve #5. I have changed the stripping pattern to account for additional escape sequence. However, I am not aware of all escape sequences, so I might have missed something. 

All test passes and I have tested it with the example provided by @kiliankoe in the issue thread.
I have also added two additional stripping test that fail on master.

I would advise some testing before merging.