### PR TITLE
Changed accessibility of TextTable.columns to public private(set)

### DIFF
--- a/Source/SwiftyTextTable/TextTable.swift
+++ b/Source/SwiftyTextTable/TextTable.swift
@@ -181,7 +181,7 @@ public struct TextTableColumn {
     }
 
     /// The values contained in this column. Each value represents another row.
-    fileprivate var values: [String] = [] {
+    public private(set) var values: [String] = [] {
         didSet {
             computeWidth()
         }

--- a/Source/SwiftyTextTable/TextTable.swift
+++ b/Source/SwiftyTextTable/TextTable.swift
@@ -38,7 +38,7 @@ private extension String {
 public struct TextTable {
 
     /// The columns within the table.
-    private var columns: [TextTableColumn]
+    public private(set) var columns: [TextTableColumn]
 
     /// The `String` used to separate columns in the table. Defaults to "|".
     public var columnFence = "|"

--- a/Source/SwiftyTextTable/TextTable.swift
+++ b/Source/SwiftyTextTable/TextTable.swift
@@ -181,7 +181,7 @@ public struct TextTableColumn {
     }
 
     /// The values contained in this column. Each value represents another row.
-    public private(set) var values: [String] = [] {
+    public fileprivate(set) var values: [String] = [] {
         didSet {
             computeWidth()
         }


### PR DESCRIPTION
I'm writing an extension that allows JSON output for interaction with other scripts – it required me to open up access to the columns property. I thought I'd send it upstream for those in a similar boat.

I don't think write access is appropriate, as that is what the addRow/addRows functions are for.