### PR TITLE
Added optional rigtht justification to a TableColumn

### DIFF
--- a/Source/SwiftyTextTable/TextTable.swift
+++ b/Source/SwiftyTextTable/TextTable.swift
@@ -134,12 +134,12 @@ public struct TextTable {
         let top = renderTableHeader() ?? separator
 
         let columnHeaders = fence(
-            strings: columns.map({ " \($0.header.withPadding(count: $0.width())) " }),
+            strings: columns.map({ " \($0.header.withPadding(count: $0.width(), rightJustify: $0.rightJustify)) " }),
             separator: columnFence
         )
 
         let values = columns.isEmpty ? "" : (0..<columns.first!.values.count).map({ rowIndex in
-            fence(strings: columns.map({ " \($0.values[rowIndex].withPadding(count: $0.width())) " }), separator: columnFence)
+            fence(strings: columns.map({ " \($0.values[rowIndex].withPadding(count: $0.width(), rightJustify: $0.rightJustify)) " }), separator: columnFence)
         }).paragraph()
 
         return [top, columnHeaders, separator, values, separator].paragraph()
@@ -179,6 +179,7 @@ public struct TextTableColumn {
             computeWidth()
         }
     }
+    public var rightJustify : Bool = false
 
     /// The values contained in this column. Each value represents another row.
     fileprivate var values: [String] = [] {
@@ -255,12 +256,12 @@ public extension Array where Element: TextTableRepresentable {
 // MARK: - Helper Extensions
 
 private extension String {
-    func withPadding(count: Int) -> String {
+    func withPadding(count: Int, rightJustify: Bool = false) -> String {
         let length = self.strippedLength()
 
         if length < count {
-            return self +
-                repeatElement(" ", count: count - length).joined()
+            let padding = repeatElement(" ", count: count - length).joined()
+            return rightJustify ? padding + self : self + padding
         }
         return self
     }

--- a/SwiftyTextTable.xcodeproj/project.pbxproj
+++ b/SwiftyTextTable.xcodeproj/project.pbxproj
@@ -183,6 +183,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 3B5BDCDC1C63133100592068;
@@ -379,7 +380,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Source/SwiftyTextTable/Supporting Files/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.scotthoyt.SwiftyTextTable;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -403,7 +404,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Source/SwiftyTextTable/Supporting Files/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.scotthoyt.SwiftyTextTable;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -418,6 +419,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = "Tests/SwiftyTextTableTests/Supporting Files/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.scotthoyt.SwiftyTextTableTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
@@ -431,6 +433,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = "Tests/SwiftyTextTableTests/Supporting Files/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.scotthoyt.SwiftyTextTableTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;

--- a/Tests/SwiftyTextTableTests/SwiftyTextTableTests.swift
+++ b/Tests/SwiftyTextTableTests/SwiftyTextTableTests.swift
@@ -11,11 +11,15 @@ import SwiftyTextTable
 
 class SwiftyTextTableTests: XCTestCase {
 
-    func fooTable() -> TextTable {
+    func fooTable(withRightJustify: Bool = false) -> TextTable {
         let foo = TextTableColumn(header: "foo")
-        let bar = TextTableColumn(header: "bar")
+        var bar = TextTableColumn(header: "bar")
         let baz = TextTableColumn(header: "baz")
+        bar.rightJustify = withRightJustify
         var table = TextTable(columns: [foo, bar, baz])
+        if withRightJustify {
+            table.header = "RIGHT JUSTIFY!"
+        }
         table.addRow(values: ["1", "2"])
         table.addRow(values: [11, 22, 33])
         table.addRow(values: [111, 222, 333, 444])
@@ -33,6 +37,13 @@ class SwiftyTextTableTests: XCTestCase {
                        "+-----+-----+-----+"
         XCTAssertEqual(output, expected)
     }
+    
+    func testPrintRightJustify(){
+        let output = fooTable(withRightJustify: true).render()
+        print( output)
+    }
+    
+    
 
     func testRenderDefaultWithHeader() {
         var table = fooTable()


### PR DESCRIPTION
I needed to right justify columns that have numbers in them.
This is added in a lightweight manner. TableColumn has a "rightJustify" property. If you set that to "true" the column will be right justified. 

I also had to update the deployment target from MacOS 10.10 to 13 